### PR TITLE
improve reporter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 var
-	es          = require('event-stream'),
-	Lintspaces  = require('lintspaces'),
-	PluginError = require('gulp-util').PluginError,
-	log         = require('gulp-util').log,
-	colors      = require('gulp-util').colors
+	es		= require('event-stream'),
+	Lintspaces	= require('lintspaces'),
+	gutil		= require('gulp-util'),
+	path		= require('path'),
+	appRoot		= require('app-root-path'),
+	colors		= require('colors/safe'),
+	logSymbols	= require('log-symbols')
 ;
 
 module.exports = function(options) {
@@ -24,31 +26,59 @@ module.exports = function(options) {
 	});
 };
 
-module.exports.reporter = function() {
-	return es.through(function(file) {
+module.exports.reporter = function(options) {
+	var opts = {
+		breakOnWarning: false,
+    prefixLogs: false
+	};
+	for (var attr in options) { opts[attr] = options[attr]; }
+	var totalWarningCount = 0;
+	var logPrefix = options.prefixLogs ? colors.cyan('[gulp-lintspaces]\t') : '';
+
+	function reportFile (filepath, data) {
+		var lines = [];
+		var warningLines = Object.keys(data);
+		var warningCount = Object.keys(data).length;
+
+		// Report Filename
+		lines.push(colors.white.bold.underline(path.relative(appRoot.path, filepath)));
+		// Loop through and report warnings
+		warningLines.forEach(function (warningLine) {
+			var line = colors.grey('  line ' + data[warningLine][0].line) + '\t\t  ' + colors.cyan(data[warningLine][0].message);
+			lines.push(line);
+		});
+		lines.push('');
+		lines.push('  ' + logSymbols.info + ' ' + colors.blue(warningCount + ' whitespace warning' + (warningCount !== 1 ? 's' : '')));
+		lines = lines.map(function(line) { return logPrefix + line; });
+
+		return lines.join('\n') + '\n';
+	}
+
+	// Add report summary
+	function reportSummary () {
+		if (totalWarningCount === 0) {
+			// Success!
+		} else {
+			console.log(logPrefix + logSymbols.info + colors.blue(' ' + totalWarningCount + ' whitespace warning' + (totalWarningCount !== 1 ? 's' : '') + '\n'));
+		}
+	}
+
+	return es.through(function (file) {
 		if (file.isNull()) {
 			return this.emit('data', file);
 		}
 
+		// Report file specific stuff only when there are warnings
 		if (file.lintspaces && Object.keys(file.lintspaces).length) {
-			for (var line in file.lintspaces) {
-				file.lintspaces[line].forEach(function(error) {
-					log(
-						'gulp-lintspaces',
-						[
-							colors.red(error.message),
-							'in',
-							file.path + ':' + line
-						].join(' ')
-					);
-				});
-			}
+			totalWarningCount += Object.keys(file.lintspaces).length;
+			console.log(reportFile(file.path, file.lintspaces));
 		}
-
-		if (Object.keys(file.lintspaces).length) {
-			this.emit('error', new PluginError("gulp-lintspaces", "Found spacing errors"));
-		}
-
 		return this.emit('data', file);
+	})
+	.on('end', function () {
+		reportSummary();
+		if (totalWarningCount && options.breakOnWarning) {
+			this.emit('error', new gutil.PluginError('gulp-lintspaces', 'Linter warnings occurred!'));
+		}
 	});
-}
+};

--- a/package.json
+++ b/package.json
@@ -25,9 +25,13 @@
   "author": "Christopher Knötschke <cknoetschke@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "gulp-util": "^2.2.14",
+    "app-root-path": "^1.0.0",
+    "colors": "^1.0.3",
     "event-stream": "^3.1.1",
-    "lintspaces": "^0.3.2"
+    "gulp-util": "^2.2.14",
+    "lintspaces": "^0.3.2",
+    "log-symbols": "^1.0.2",
+    "path": "^0.11.14"
   },
   "devDependencies": {
     "should": "^3.2.0",


### PR DESCRIPTION
This is what the current output of both the `gulp-lintspaces` and `gulp-semistandard` reporters looks like. It's a bit confusing, since they're both logging messages at the same time. I added a `[gulp-lintspaces]` prefix to this one. We might have to add a prefix to the semistandard reporter as well. 

![screen shot 2016-01-26 at 4 52 46 pm](https://cloud.githubusercontent.com/assets/516388/12592922/b653d664-c455-11e5-863d-f01f81bf5a46.png)
